### PR TITLE
Added config to allow 'old' Land Protector

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -352,3 +352,9 @@ skill_eightpath_algorithm: yes
 // The official setting makes it quite easy to trap MVPs, set this to 31 if you want all units to be able to
 // damage skills (previous behavior).
 can_damage_skill: 1
+
+// Land Protector behavior
+// 0 : Officially, standing players at the border (outer cell) of the Land Protector is still can be affected/hit
+//     by AoE skills (if the skills has splash effect, such Storm Gust).
+// 1 : Old Athena style, totally ignore AoE skill from outside Land Protector area.
+land_protector_behavior: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8233,6 +8233,7 @@ static const struct _battle_data {
 	{ "cashshop_show_points",               &battle_config.cashshop_show_points,            0,      0,      1,              },
 	{ "mail_show_status",                   &battle_config.mail_show_status,                0,      0,      2,              },
 	{ "client_limit_unit_lv",               &battle_config.client_limit_unit_lv,            0,      0,      BL_ALL,         },
+	{ "land_protector_behavior",            &battle_config.land_protector_behavior,         0,      0,      1,              },
 // BattleGround Settings
 	{ "bg_update_interval",                 &battle_config.bg_update_interval,              1000,   100,    INT_MAX,        },
 	{ "bg_short_attack_damage_rate",        &battle_config.bg_short_damage_rate,            80,     0,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -331,6 +331,7 @@ extern struct Battle_Config
 	int item_drop_adddrop_min,item_drop_adddrop_max; //[Skotlex]
 
 	int prevent_logout;	// Added by RoVeRT
+	int land_protector_behavior;
 
 	int alchemist_summon_reward;	// [Valaris]
 	int drops_by_luk;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -13077,7 +13077,7 @@ static int skill_unit_onplace(struct skill_unit *unit, struct block_list *bl, un
 
 	tstatus = status_get_status_data(bl);
 
-	if( (skill_get_type(sg->skill_id) == BF_MAGIC && map_getcell(unit->bl.m, unit->bl.x, unit->bl.y, CELL_CHKLANDPROTECTOR) && sg->skill_id != SA_LANDPROTECTOR) ||
+	if( (skill_get_type(sg->skill_id) == BF_MAGIC && ((battle_config.land_protector_behavior) ? map_getcell(bl->m, bl->x, bl->y, CELL_CHKLANDPROTECTOR) : map_getcell(unit->bl.m, unit->bl.x, unit->bl.y, CELL_CHKLANDPROTECTOR)) && sg->skill_id != SA_LANDPROTECTOR) ||
 		map_getcell(bl->m, bl->x, bl->y, CELL_CHKMAELSTROM) )
 		return 0; //AoE skills are ineffective. [Skotlex]
 
@@ -18048,7 +18048,7 @@ int skill_unit_timer_sub_onplace(struct block_list* bl, va_list ap)
 
 	nullpo_ret(group = unit->group);
 
-	if( !(skill_get_inf2(group->skill_id)&(INF2_SONG_DANCE|INF2_TRAP)) && !(skill_get_inf3(group->skill_id)&(INF3_NOLP)) && group->skill_id != NC_NEUTRALBARRIER && map_getcell(unit->bl.m, unit->bl.x, unit->bl.y, CELL_CHKLANDPROTECTOR) )
+	if( !(skill_get_inf2(group->skill_id)&(INF2_SONG_DANCE|INF2_TRAP)) && !(skill_get_inf3(group->skill_id)&(INF3_NOLP)) && group->skill_id != NC_NEUTRALBARRIER && (battle_config.land_protector_behavior ? map_getcell(bl->m, bl->x, bl->y, CELL_CHKLANDPROTECTOR) : map_getcell(unit->bl.m, unit->bl.x, unit->bl.y, CELL_CHKLANDPROTECTOR)) )
 		return 0; //AoE skills are ineffective. [Skotlex]
 
 	if( battle_check_target(&unit->bl,bl,group->target_flag) <= 0 )


### PR DESCRIPTION
* The config is default to `land_protector_behavior: 0`
* As follow up of e7e8b54 and people's thought at https://github.com/rathena/rathena/issues/1404

Signed-off-by: Cydh Ramdh <cydh@pservero.com>

-----

See https://rathena.org/board/topic/107922-old-land-protector/